### PR TITLE
Bbs plus correction and add multi message signing/verifying

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,8 +152,8 @@
 					</execution>
 				</executions>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+					<source>9</source>
+					<target>9</target>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -240,7 +240,7 @@
 		<dependency>
 			<groupId>com.github.mattrglobal</groupId>
 			<artifactId>bbs.signatures</artifactId>
-			<version>1.5-21-07-2021</version>
+			<version>1.6-SNAPSHOT</version>
 			<optional>true</optional>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -45,19 +45,11 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<github.global.server>github</github.global.server>
 		<maven-release-plugin.version>2.5.3</maven-release-plugin.version>
+		<kotlin.version>1.8.20-Beta</kotlin.version>
 	</properties>
 
 	<build>
 		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.8.1</version>
-				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
-				</configuration>
-			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-source-plugin</artifactId>
@@ -101,6 +93,67 @@
 				<configuration>
 					<scmCommentPrefix>[skip ci]</scmCommentPrefix>
 					<tagNameFormat>@{project.version}</tagNameFormat>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.jetbrains.kotlin</groupId>
+				<artifactId>kotlin-maven-plugin</artifactId>
+				<version>${kotlin.version}</version>
+				<executions>
+					<execution>
+						<id>compile</id>
+						<phase>compile</phase>
+						<goals>
+							<goal>compile</goal>
+						</goals>
+						<configuration>
+							<sourceDirs>
+								<source>src/main/java</source>
+								<source>target/generated-sources/annotations</source>
+							</sourceDirs>
+						</configuration>
+					</execution>
+					<execution>
+						<id>test-compile</id>
+						<phase>test-compile</phase>
+						<goals>
+							<goal>test-compile</goal>
+						</goals>
+						<configuration>
+							<sourceDirs>
+								<source>src/test/java</source>
+								<source>target/generated-test-sources/test-annotations</source>
+							</sourceDirs>
+						</configuration>
+					</execution>
+				</executions>
+				<configuration>
+					<jvmTarget>1.8</jvmTarget>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.8.1</version>
+				<executions>
+					<execution>
+						<id>compile</id>
+						<phase>compile</phase>
+						<goals>
+							<goal>compile</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>testCompile</id>
+						<phase>test-compile</phase>
+						<goals>
+							<goal>testCompile</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<source>1.8</source>
+					<target>1.8</target>
 				</configuration>
 			</plugin>
 		</plugins>
@@ -200,6 +253,17 @@
 					<artifactId>bcprov-jdk15on</artifactId>
 				</exclusion>
 			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.jetbrains.kotlin</groupId>
+			<artifactId>kotlin-stdlib-jdk8</artifactId>
+			<version>${kotlin.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.jetbrains.kotlin</groupId>
+			<artifactId>kotlin-test</artifactId>
+			<version>${kotlin.version}</version>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 

--- a/src/main/java/com/danubetech/keyformats/crypto/PublicKeyVerifierFactory.java
+++ b/src/main/java/com/danubetech/keyformats/crypto/PublicKeyVerifierFactory.java
@@ -37,10 +37,10 @@ public class PublicKeyVerifierFactory {
             if (JWSAlgorithm.ES256KCC.equals(algorithm)) return new secp256k1_ES256KCC_PublicKeyVerifier((ECKey) publicKey);
         } else if (KeyTypeName.Bls12381G1.equals(keyTypeName)) {
 
-            if (JWSAlgorithm.BBSPlus.equals(algorithm)) return new Bls12381G1_BBSPlus_PublicKeyVerifier((bbs.signatures.KeyPair) publicKey);
+            if (JWSAlgorithm.BBSPlus.equals(algorithm)) return new Bls12381G1_BBSPlus_PublicKeyVerifier((byte[]) publicKey);
         } else if (KeyTypeName.Bls12381G2.equals(keyTypeName)) {
 
-            if (JWSAlgorithm.BBSPlus.equals(algorithm)) return new Bls12381G2_BBSPlus_PublicKeyVerifier((bbs.signatures.KeyPair) publicKey);
+            if (JWSAlgorithm.BBSPlus.equals(algorithm)) return new Bls12381G2_BBSPlus_PublicKeyVerifier((byte[]) publicKey);
         } else if (KeyTypeName.Bls48581G1.equals(keyTypeName)) {
 
             if (JWSAlgorithm.BBSPlus.equals(algorithm)) return new Bls48581G1_BBSPlus_PublicKeyVerifier((bbs.signatures.KeyPair) publicKey);

--- a/src/main/java/com/danubetech/keyformats/crypto/impl/BBSPlus_PrivateKeySigner.java
+++ b/src/main/java/com/danubetech/keyformats/crypto/impl/BBSPlus_PrivateKeySigner.java
@@ -26,6 +26,13 @@ public class BBSPlus_PrivateKeySigner extends PrivateKeySigner<byte[]> {
         return sign(List.of(content));
     }
 
+    public final byte[] sign(List<byte[]> content, String algorithm) throws GeneralSecurityException {
+
+        if (! algorithm.equals(getAlgorithm())) throw new GeneralSecurityException("Unexpected algorithm " + algorithm + " is different from " + getAlgorithm());
+
+        return this.sign(content);
+    }
+
     public byte[] sign(List<byte[]> content) throws GeneralSecurityException {
         try {
             return Bbs.blsSign(getPrivateKey(), publicKey, content.toArray(new byte[content.size()][]));

--- a/src/main/java/com/danubetech/keyformats/crypto/impl/BBSPlus_PrivateKeySigner.java
+++ b/src/main/java/com/danubetech/keyformats/crypto/impl/BBSPlus_PrivateKeySigner.java
@@ -1,0 +1,38 @@
+package com.danubetech.keyformats.crypto.impl;
+
+import bbs.signatures.Bbs;
+import bbs.signatures.KeyPair;
+import com.danubetech.keyformats.crypto.PrivateKeySigner;
+import com.danubetech.keyformats.jose.JWSAlgorithm;
+
+import java.security.GeneralSecurityException;
+import java.util.List;
+
+public class BBSPlus_PrivateKeySigner extends PrivateKeySigner<byte[]> {
+
+    private final byte[] publicKey;
+
+    public BBSPlus_PrivateKeySigner(KeyPair keyPair) {
+        super( keyPair.secretKey, JWSAlgorithm.BBSPlus);
+        int keySize = Bbs.getSecretKeySize();
+        if (keyPair.secretKey.length != keySize) {
+            throw new IllegalArgumentException("wrong key size: expected: " + keySize + "but was " + keyPair.secretKey.length);
+        }
+        publicKey = keyPair.publicKey;
+    }
+
+    @Override
+    public byte[] sign(byte[] content) throws GeneralSecurityException {
+        return sign(List.of(content));
+    }
+
+    public byte[] sign(List<byte[]> content) throws GeneralSecurityException {
+        try {
+            return Bbs.blsSign(getPrivateKey(), publicKey, content.toArray(new byte[content.size()][]));
+        } catch (GeneralSecurityException ex) {
+            throw ex;
+        } catch (Exception ex) {
+            throw new GeneralSecurityException(ex.getMessage(), ex);
+        }
+    }
+}

--- a/src/main/java/com/danubetech/keyformats/crypto/impl/BBSPlus_PublicKeyVerifier.java
+++ b/src/main/java/com/danubetech/keyformats/crypto/impl/BBSPlus_PublicKeyVerifier.java
@@ -1,7 +1,6 @@
 package com.danubetech.keyformats.crypto.impl;
 
 import bbs.signatures.Bbs;
-import bbs.signatures.KeyPair;
 import com.danubetech.keyformats.crypto.PublicKeyVerifier;
 import com.danubetech.keyformats.jose.JWSAlgorithm;
 
@@ -17,6 +16,13 @@ public class BBSPlus_PublicKeyVerifier extends PublicKeyVerifier<byte[]> {
     @Override
     public boolean verify(byte[] content, byte[] signature) throws GeneralSecurityException {
         return verify(List.of(content), signature);
+    }
+
+    public final boolean verify(List<byte[]> content, byte[] signature, String algorithm) throws GeneralSecurityException {
+        if (!algorithm.equals(getAlgorithm())) {
+            throw new GeneralSecurityException("Unexpected algorithm " + algorithm + " is different from " + getAlgorithm());
+        }
+        return this.verify(content, signature);
     }
 
     public boolean verify(List<byte[]> content, byte[] signature) throws GeneralSecurityException {

--- a/src/main/java/com/danubetech/keyformats/crypto/impl/BBSPlus_PublicKeyVerifier.java
+++ b/src/main/java/com/danubetech/keyformats/crypto/impl/BBSPlus_PublicKeyVerifier.java
@@ -1,0 +1,32 @@
+package com.danubetech.keyformats.crypto.impl;
+
+import bbs.signatures.Bbs;
+import bbs.signatures.KeyPair;
+import com.danubetech.keyformats.crypto.PublicKeyVerifier;
+import com.danubetech.keyformats.jose.JWSAlgorithm;
+
+import java.security.GeneralSecurityException;
+import java.util.List;
+
+public class BBSPlus_PublicKeyVerifier extends PublicKeyVerifier<byte[]> {
+
+    public BBSPlus_PublicKeyVerifier(byte[] publicKey) {
+        super(publicKey, JWSAlgorithm.BBSPlus);
+    }
+
+    @Override
+    public boolean verify(byte[] content, byte[] signature) throws GeneralSecurityException {
+        return verify(List.of(content), signature);
+    }
+
+    public boolean verify(List<byte[]> content, byte[] signature) throws GeneralSecurityException {
+        try {
+            return Bbs.blsVerify(getPublicKey(), signature, content.toArray(new byte[content.size()][]));
+        } catch (GeneralSecurityException ex) {
+            throw ex;
+        } catch (Exception ex) {
+            throw new GeneralSecurityException(ex.getMessage(), ex);
+        }
+    }
+
+}

--- a/src/main/java/com/danubetech/keyformats/crypto/impl/Bls12381G1_BBSPlus_PrivateKeySigner.java
+++ b/src/main/java/com/danubetech/keyformats/crypto/impl/Bls12381G1_BBSPlus_PrivateKeySigner.java
@@ -7,25 +7,9 @@ import com.danubetech.keyformats.jose.JWSAlgorithm;
 
 import java.security.GeneralSecurityException;
 
-public class Bls12381G1_BBSPlus_PrivateKeySigner extends PrivateKeySigner<KeyPair> {
+public class Bls12381G1_BBSPlus_PrivateKeySigner extends BBSPlus_PrivateKeySigner {
 
-    public Bls12381G1_BBSPlus_PrivateKeySigner(KeyPair privateKey) {
-
-        super(privateKey, JWSAlgorithm.BBSPlus);
-    }
-
-    @Override
-    public byte[] sign(byte[] content) throws GeneralSecurityException {
-
-        try {
-
-            return Bbs.blsSign(this.getPrivateKey().secretKey, this.getPrivateKey().publicKey, new byte[][]{content});
-        } catch (GeneralSecurityException ex) {
-
-            throw ex;
-        } catch (Exception ex) {
-
-            throw new GeneralSecurityException(ex.getMessage(), ex);
-        }
+    public Bls12381G1_BBSPlus_PrivateKeySigner(KeyPair keyPair) {
+        super(keyPair);
     }
 }

--- a/src/main/java/com/danubetech/keyformats/crypto/impl/Bls12381G1_BBSPlus_PublicKeyVerifier.java
+++ b/src/main/java/com/danubetech/keyformats/crypto/impl/Bls12381G1_BBSPlus_PublicKeyVerifier.java
@@ -1,31 +1,14 @@
 package com.danubetech.keyformats.crypto.impl;
 
 import bbs.signatures.Bbs;
-import bbs.signatures.KeyPair;
-import com.danubetech.keyformats.crypto.PublicKeyVerifier;
-import com.danubetech.keyformats.jose.JWSAlgorithm;
 
-import java.security.GeneralSecurityException;
+public class Bls12381G1_BBSPlus_PublicKeyVerifier extends BBSPlus_PublicKeyVerifier {
 
-public class Bls12381G1_BBSPlus_PublicKeyVerifier extends PublicKeyVerifier<KeyPair> {
-
-    public Bls12381G1_BBSPlus_PublicKeyVerifier(KeyPair publicKey) {
-
-        super(publicKey, JWSAlgorithm.BBSPlus);
-    }
-
-    @Override
-    public boolean verify(byte[] content, byte[] signature) throws GeneralSecurityException {
-
-        try {
-
-            return Bbs.blsVerify(this.getPublicKey().publicKey, signature, new byte[][]{signature});
-        } catch (GeneralSecurityException ex) {
-
-            throw ex;
-        } catch (Exception ex) {
-
-            throw new GeneralSecurityException(ex.getMessage(), ex);
+    public Bls12381G1_BBSPlus_PublicKeyVerifier(byte[] publicKey) {
+        super(publicKey);
+        int keySize = Bbs.getBls12381G1PublicKeySize();
+        if (publicKey.length != keySize) {
+            throw new IllegalArgumentException("wrong key size: expected: " + keySize + "but was " + publicKey.length);
         }
     }
 }

--- a/src/main/java/com/danubetech/keyformats/crypto/impl/Bls12381G2_BBSPlus_PrivateKeySigner.java
+++ b/src/main/java/com/danubetech/keyformats/crypto/impl/Bls12381G2_BBSPlus_PrivateKeySigner.java
@@ -7,25 +7,9 @@ import com.danubetech.keyformats.jose.JWSAlgorithm;
 
 import java.security.GeneralSecurityException;
 
-public class Bls12381G2_BBSPlus_PrivateKeySigner extends PrivateKeySigner<KeyPair> {
+public class Bls12381G2_BBSPlus_PrivateKeySigner extends BBSPlus_PrivateKeySigner {
 
-    public Bls12381G2_BBSPlus_PrivateKeySigner(KeyPair privateKey) {
-
-        super(privateKey, JWSAlgorithm.BBSPlus);
-    }
-
-    @Override
-    public byte[] sign(byte[] content) throws GeneralSecurityException {
-
-        try {
-
-            return Bbs.blsSign(this.getPrivateKey().secretKey, this.getPrivateKey().publicKey, new byte[][]{content});
-        } catch (GeneralSecurityException ex) {
-
-            throw ex;
-        } catch (Exception ex) {
-
-            throw new GeneralSecurityException(ex.getMessage(), ex);
-        }
+    public Bls12381G2_BBSPlus_PrivateKeySigner(KeyPair keyPair) {
+        super(keyPair);
     }
 }

--- a/src/main/java/com/danubetech/keyformats/crypto/impl/Bls12381G2_BBSPlus_PublicKeyVerifier.java
+++ b/src/main/java/com/danubetech/keyformats/crypto/impl/Bls12381G2_BBSPlus_PublicKeyVerifier.java
@@ -19,7 +19,7 @@ public class Bls12381G2_BBSPlus_PublicKeyVerifier extends PublicKeyVerifier<KeyP
 
         try {
 
-            return Bbs.blsVerify(this.getPublicKey().publicKey, signature, new byte[][]{signature});
+            return Bbs.blsVerify(this.getPublicKey().publicKey, signature, new byte[][]{content});
         } catch (GeneralSecurityException ex) {
 
             throw ex;

--- a/src/main/java/com/danubetech/keyformats/crypto/impl/Bls12381G2_BBSPlus_PublicKeyVerifier.java
+++ b/src/main/java/com/danubetech/keyformats/crypto/impl/Bls12381G2_BBSPlus_PublicKeyVerifier.java
@@ -7,25 +7,12 @@ import com.danubetech.keyformats.jose.JWSAlgorithm;
 
 import java.security.GeneralSecurityException;
 
-public class Bls12381G2_BBSPlus_PublicKeyVerifier extends PublicKeyVerifier<KeyPair> {
-
-    public Bls12381G2_BBSPlus_PublicKeyVerifier(KeyPair publicKey) {
-
-        super(publicKey, JWSAlgorithm.BBSPlus);
-    }
-
-    @Override
-    public boolean verify(byte[] content, byte[] signature) throws GeneralSecurityException {
-
-        try {
-
-            return Bbs.blsVerify(this.getPublicKey().publicKey, signature, new byte[][]{content});
-        } catch (GeneralSecurityException ex) {
-
-            throw ex;
-        } catch (Exception ex) {
-
-            throw new GeneralSecurityException(ex.getMessage(), ex);
+public class Bls12381G2_BBSPlus_PublicKeyVerifier extends BBSPlus_PublicKeyVerifier {
+    public Bls12381G2_BBSPlus_PublicKeyVerifier(byte[] publicKey) {
+        super(publicKey);
+        int keySize = Bbs.getBls12381G2PublicKeySize();
+        if (publicKey.length != keySize) {
+            throw new IllegalArgumentException("wrong key size: expected: " + keySize + "but was " + publicKey.length);
         }
     }
 }

--- a/src/test/java/com/danubetech/keyformats/crypto/Bls12381G2_BBSPlus_PublicKeyVerifierTest.kt
+++ b/src/test/java/com/danubetech/keyformats/crypto/Bls12381G2_BBSPlus_PublicKeyVerifierTest.kt
@@ -25,7 +25,21 @@ class Bls12381G2_BBSPlusTest {
 
     @Test
     fun signAndVerifyListOfMessages() {
-        val content = listOf(Random.nextBytes(32), Random.nextBytes(32), Random.nextBytes(32))
+        val content = List(3) { Random.nextBytes(32) }
+        val keyPair = Bbs.generateBls12381G2Key(Random.nextBytes(32))
+        val signature = Bls12381G2_BBSPlus_PrivateKeySigner(keyPair).run {
+            sign(content)
+        }
+        assertEquals(signature.size, 112)
+        val verifyResult = Bls12381G2_BBSPlus_PublicKeyVerifier(keyPair.publicKey).run {
+            verify(content, signature)
+        }
+        assertTrue(verifyResult)
+    }
+
+    @Test
+    fun signAndVerifyLongListOfMessages() {
+        val content = List(20) { Random.nextBytes(32) }
         val keyPair = Bbs.generateBls12381G2Key(Random.nextBytes(32))
         val signature = Bls12381G2_BBSPlus_PrivateKeySigner(keyPair).run {
             sign(content)

--- a/src/test/java/com/danubetech/keyformats/crypto/Bls12381G2_BBSPlus_PublicKeyVerifierTest.kt
+++ b/src/test/java/com/danubetech/keyformats/crypto/Bls12381G2_BBSPlus_PublicKeyVerifierTest.kt
@@ -10,16 +10,31 @@ import kotlin.test.assertTrue
 
 class Bls12381G2_BBSPlusTest {
     @Test
-    fun signAndVerifyContent() {
+    fun signAndVerifySingleMessage() {
         val content = Random.nextBytes(32)
         val keyPair = Bbs.generateBls12381G2Key(Random.nextBytes(32))
         val signature = Bls12381G2_BBSPlus_PrivateKeySigner(keyPair).run {
             sign(content)
         }
         assertEquals(signature.size, 112)
-        val verifyResult = Bls12381G2_BBSPlus_PublicKeyVerifier(keyPair).run {
+        val verifyResult = Bls12381G2_BBSPlus_PublicKeyVerifier(keyPair.publicKey).run {
             verify(content, signature)
         }
         assertTrue(verifyResult)
     }
+
+    @Test
+    fun signAndVerifyListOfMessages() {
+        val content = listOf(Random.nextBytes(32), Random.nextBytes(32), Random.nextBytes(32))
+        val keyPair = Bbs.generateBls12381G2Key(Random.nextBytes(32))
+        val signature = Bls12381G2_BBSPlus_PrivateKeySigner(keyPair).run {
+            sign(content)
+        }
+        assertEquals(signature.size, 112)
+        val verifyResult = Bls12381G2_BBSPlus_PublicKeyVerifier(keyPair.publicKey).run {
+            verify(content, signature)
+        }
+        assertTrue(verifyResult)
+    }
+
 }

--- a/src/test/java/com/danubetech/keyformats/crypto/Bls12381G2_BBSPlus_PublicKeyVerifierTest.kt
+++ b/src/test/java/com/danubetech/keyformats/crypto/Bls12381G2_BBSPlus_PublicKeyVerifierTest.kt
@@ -1,0 +1,25 @@
+package com.danubetech.keyformats.crypto
+
+import bbs.signatures.Bbs
+import com.danubetech.keyformats.crypto.impl.Bls12381G2_BBSPlus_PrivateKeySigner
+import com.danubetech.keyformats.crypto.impl.Bls12381G2_BBSPlus_PublicKeyVerifier
+import org.junit.jupiter.api.Test
+import kotlin.random.Random
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class Bls12381G2_BBSPlusTest {
+    @Test
+    fun signAndVerifyContent() {
+        val content = Random.nextBytes(32)
+        val keyPair = Bbs.generateBls12381G2Key(Random.nextBytes(32))
+        val signature = Bls12381G2_BBSPlus_PrivateKeySigner(keyPair).run {
+            sign(content)
+        }
+        assertEquals(signature.size, 112)
+        val verifyResult = Bls12381G2_BBSPlus_PublicKeyVerifier(keyPair).run {
+            verify(content, signature)
+        }
+        assertTrue(verifyResult)
+    }
+}


### PR DESCRIPTION
The changes in the pom file are required to run the unit tests (kotlin). Feel free to only merge the source changes and keep the project pure java.

The PrivateKeySigner derived from the ByteSigner only allows signing  a single ByteArray. The BBSPlus_PrivateKeySigner extends the PrivateKeySigner by a method for signing a List of ByteArrays. This is required to use this library to create ld-signatures  by signing a list of digested statements.